### PR TITLE
Add Travis CI support, using SBCL 64 bit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.fasl
 \#*
 .*
+!.travis.yml
 !.gitignore
 wordnet30.sqlite
 *.auto.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: lisp
+
+env:
+  matrix:
+#    - LISP=abcl
+#    - LISP=allegro
+   - LISP=sbcl
+#    - LISP=sbcl32
+#    - LISP=ccl
+#    - LISP=ccl32
+#    - LISP=clisp
+#    - LISP=clisp32
+#    - LISP=cmucl
+#    - LISP=ecl
+
+#matrix:
+#  allow_failures:
+#    - env: LISP=sbcl
+
+install:
+  - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-nlp' > /dev/null;
+    then
+      ./install.sh;
+    else
+      curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
+    fi     
+        
+before_script:
+    - cd $HOME/lisp
+    - git clone https://github.com/vseloved/rutils.git
+    - git clone https://github.com/vseloved/should-test.git
+
+script:
+    - sbcl --non-interactive --eval '(progn (pushnew :dev *features*) (ql:quickload :cl-nlp) (asdf:test-system :cl-nlp))'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/vseloved/cl-nlp.png?branch=master)](https://travis-ci.org/vseloved/cl-nlp)
+
 # CL-NLP -- a Lisp NLP toolkit
 
 ## Brief description

--- a/cl-nlp.asd
+++ b/cl-nlp.asd
@@ -99,4 +99,5 @@
                       ((:file "greedy-ap-test")))
              (:module #:user
                       :components
-                      ((:file "user-test")))))))
+                      ((:file "user-test")))
+             (:file "ci")))))

--- a/test/ci.lisp
+++ b/test/ci.lisp
@@ -1,0 +1,9 @@
+;;; Test operation to test entire NLP test suite
+;;; This test operation is also used by Travis CI
+
+(defmethod asdf:perform ((o asdf:test-op)
+                         (s (eql (asdf:find-system :cl-nlp))))
+  (asdf:load-system :cl-nlp)
+  ;;; TO DO: Fix and add other package tests
+  (should-test:test :package :ncore)
+  t)


### PR DESCRIPTION
1. Add travis CI config tweaked from cl-travis.
2. Exclude travis CI config from git ignore list.
3. Add travis logo to README.
4. Add system test operation in a new test file.
5. Add the new test file to system definition.

Initially only ncore package is tested. Other package tests and more lisps to
be added.
