### PR TITLE
Fix the treebank test

### DIFF
--- a/test/ci.lisp
+++ b/test/ci.lisp
@@ -5,5 +5,6 @@
                          (s (eql (asdf:find-system :cl-nlp))))
   (asdf:load-system :cl-nlp)
   ;;; TO DO: Fix and add other package tests
-  (should-test:test :package :ncore)
+  (dolist (package '(:ncore :ncorp))
+    (should-test:test :package package))
   t)

--- a/test/corpora/treebank-test.lisp
+++ b/test/corpora/treebank-test.lisp
@@ -14,16 +14,18 @@
 
 
 (deftest read-treebank ()
-  (should be equal '((S (NP-SBJ "I")
+  (should be equal '((S (NLP.TAGS::NP-SBJ "I")
                         (VP "do" "not"
                             (VP "mind"
-                                (S (NP-SBJ "you(r)")
+                                (S (NLP.TAGS::NP-SBJ "you(r)")
                                    (VP "leaving"
-                                       (ADV-TMP "early")))))))
+                                       (NLP.TAGS::ADV-TMP "early")))))))
           (with-tmp-file (f "(S (NP-SBJ I)
                                 (VP do not
                                     (VP mind
                                         (S (NP-SBJ you(r))
                                            (VP leaving
                                                (ADV-TMP early))))))")
-            (read-corpus-file :treebank f))))
+	    (mv-bind (nil? tokens-str tokens trees)
+		(read-corpus-file :treebank f)
+	      trees))))


### PR DESCRIPTION
This PR:
1. Fixes the treebank test.
2. Adds ncorp module to system tests.
