### PR TITLE
Fix tabulate tests

### DIFF
--- a/test/ci.lisp
+++ b/test/ci.lisp
@@ -5,6 +5,6 @@
                          (s (eql (asdf:find-system :cl-nlp))))
   (asdf:load-system :cl-nlp)
   ;;; TO DO: Fix and add other package tests
-  (dolist (package '(:ncore :ncorp :ntag))
+  (dolist (package '(:ncore :ncorp :ntag :nlp-user))
     (should-test:test :package package))
   t)

--- a/test/user/user-test.lisp
+++ b/test/user/user-test.lisp
@@ -6,25 +6,25 @@
 
 (deftest tabulate ()
   (should print-to *standard-output*
-"       A1  A   B1  B2
+"      A1  A   B1  B2
   ACD   1  2  133   0
     B   0  0    3  44
 " (tabulate #{:acd #{:a1 1 :a 2 :b1 133} :b #{:b1 3 :b2 44}}))
   (should print-to *standard-output*
-"       A1  A   B1   B2
+"      A1  A   B1   B2
   ACD   1  3  136  136
     B   0  0    3   47
 " (tabulate #{:acd #{:a1 1 :a 2 :b1 133} :b #{:b1 3 :b2 44}}
             :cumulative t))
   (should print-to *standard-output*
-"       A1
+"      A1
   ACD   1
     B   0
 " (tabulate #{:acd #{:a1 1 :a 2 :b1 133} :b #{:b1 3 :b2 44}}
-            :samples '(:a1)))
+            :cols '(:a1)))
   (should print-to *standard-output*
-"       1   2    3
+"      1   2    3
   ACD  1  22  333
     B  0   0    3
 " (tabulate #{:acd #{1 1 2 22 3 333} :b #{4 44 3 3}}
-            :samples '(2 3 1) :order-pred '<)))
+            :cols '(2 3 1) :order-by '<)))


### PR DESCRIPTION
1. Compute cumulative table if required.
2. Compute max cell width for each column. This also takes into account cumulative flag.
3. Modify test data to reflect minor changes in tabular output layout.
4. Update test system.
