### PR TITLE
Fix chomsky normalization and denormailization.

### DIFF
--- a/src/parsing/tree-util.lisp
+++ b/src/parsing/tree-util.lisp
@@ -24,8 +24,9 @@
                       (subrec (cdr subtree))))
                ((and (single (rest subtree))
                      (listp (second subtree)))
-                (rec (cons (mksym (fmt "~A+~A" (car subtree) (caadr subtree)))
-                           (cdadr subtree))))
+                (let ((*package* (find-package :nlp.parsing)))
+                  (rec (cons (mksym (fmt "~A+~A" (car subtree) (caadr subtree)))
+                             (cdadr subtree)))))
                (t
                 (cons (car subtree)
                       (mapcar #'rec (cdr subtree))))))
@@ -34,7 +35,8 @@
                      "Subtree ~S is improper!" nodes)
              (if (dyadic nodes)
                  (mapcar #'rec nodes)
-                 (let ((left (butlast nodes)))
+                 (let ((left (butlast nodes))
+                       (*package* (find-package :nlp.parsing)))
                    (cons (cons (mksym (fmt "~{~A~^_~}" (mapcar #'car left)))
                                (subrec left))
                          (list (rec (last1 nodes))))))))
@@ -50,8 +52,9 @@
                ((atom subtree)
                 (list subtree))
                ((find #\+ (symbol-name (car subtree)))
-                (let ((parts (mapcar #'mksym (split
-                                              #\+ (symbol-name (car subtree))))))
+                (let* ((*package* (find-package :nlp.parsing))
+                       (parts (mapcar #'mksym (split
+                                               #\+ (symbol-name (car subtree))))))
                   (list (reduce #'list (butlast parts)
                                 :from-end t
                                 :initial-value

--- a/test/ci.lisp
+++ b/test/ci.lisp
@@ -14,7 +14,7 @@
 (defun run-all-tests ()
   "Run all test modules and keep track of number of failures/errors."
   (setf *test-failures-or-errors* 0)
-  (dolist (package '(:ncore :ncorp :nlearn :ntag :nlp-user))
+  (dolist (package '(:ncore :ncorp :nlearn :ntag :nlp-user :nparse))
     (unless (should-test:test :package package)
       (incf *test-failures-or-errors* 1))))
 


### PR DESCRIPTION
1. Intern symbols in the nlp parsing package.
2. Add to test system.
