### PR TITLE
doc: rename `text-tokens' to `text-tokenized'

### DIFF
--- a/docs/user-guide/examples/eng-pos-tagger.md
+++ b/docs/user-guide/examples/eng-pos-tagger.md
@@ -89,7 +89,7 @@ Let's collect the tag distribution for each word from the WSJ section of the PTB
 
     NLP> (let ((words-dist #h(equal)))
            (map-corpus :ptb-tagged (corpus-file "ptb/TAGGED/POS/WSJ")
-                       #`(dolist (sent (text-tokens %))
+                       #`(dolist (sent (text-tokenized %))
                            (dolist (tok sent)
                              (unless (in# (token-word tok) words-dist)
                                (:= (get# (token-word tok) words-dist) #h()))
@@ -112,7 +112,7 @@ Let's do the same with its data:
 
     NLP> (let ((words-dist #h(equal)))
            (map-corpus :treebank (corpus-file "ontonotes/")
-                       #`(dolist (sent (text-tokens %))
+                       #`(dolist (sent (text-tokenized %))
                            (dolist (tok sent)
                              (with-accessors ((tag token-tag) (word token-word)) tok
                                (unless (eql tag 'tag:-NONE-)
@@ -138,7 +138,7 @@ And what about the total volume?
     NLP> (let ((total1 0)
                (total 0))
           (map-corpus :treebank "ontonotes"
-                      #`(dolist (sent (text-tokens %))
+                      #`(dolist (sent (text-tokenized %))
                           (dolist (tok sent)
                             (unless (eql (token-tag tok) 'tag:-NONE-)
                               (:+ total)
@@ -468,7 +468,7 @@ Here's a test we need:
 
     (defun extract-sents (text)
       (mapcar #`(make 'ncore:sentence :tokens (ncorp:remove-dummy-tokens %))
-              (ncore:text-tokens text)))
+              (ncore:text-tokenized text)))
 
     (defvar *tagger* (load-model (make 'greedy-ap-tagger)
                                  (models-file "pos-tagging/onf.zip")

--- a/nltk/ch1-1.md
+++ b/nltk/ch1-1.md
@@ -269,7 +269,7 @@ To use it we swap `words` in `*chat*` corpus:
 
     NLTK> (setf (text-words *chat*)
                 (mapcar #'token-word
-                        (flatten (mapcar #'text-tokens
+                        (flatten (mapcar #'text-tokenized
                                          (corpus-texts ncorp:+nps-chat-corpus+)))))
 
 But first we need to get the corpus and extract the data from it —

--- a/nltk/ch2-1.md
+++ b/nltk/ch2-1.md
@@ -468,20 +468,20 @@ First, let's examine the Brown corpus. Here are its categories:
 As you see, there is no "news" category which is mentioned in the NLTK example. Probably, what they refer to is `:press-reportage`.
 
     NLP> (take 9 (mapcar #'token-word
-                         (flatten (mapcar #'text-tokens
+                         (flatten (mapcar #'text-tokenized
                                           (get# :press-reportage
                                                 (corpus-groups *brown*))))))
     ("The" "Fulton" "County" "Grand" "Jury" "said" "Friday" "an" "investigation")
 
     NLP> (take 9 (mapcar #'token-word
                          (flatten
-                          (mapcar #'text-tokens
+                          (mapcar #'text-tokenized
                                   (remove-if-not #`(string= "cg22" (text-name %))
                                                  (corpus-texts *brown*))))))
     ("Does" "our" "society" "have" "a" "runaway" "," "uncontrollable" "growth")
 
     NLP> (setf *print-length* 3)
-    NLP> (mapcan #`(ncorpus::sentences-from-tokens (text-tokens %))
+    NLP> (mapcan #`(ncorpus::sentences-from-tokens (text-tokenized %))
                  (get# :press-reportage (corpus-groups *brown*)))
     ((#<The/at 0..3> #<Fulton/np-tl 4..10> #<County/nn-tl 11..17> ...)
      (#<The/at 166..169> #<jury/nn 170..174> #<further/rbr 175..182> ...)
@@ -517,7 +517,7 @@ category. In chapter 1 we've already done a very similar thing:
 
     NLP> (index-ngrams
           1 (mapcar #'token-word
-                    (flatten (mapcar #'text-tokens
+                    (flatten (mapcar #'text-tokenized
                                      (get# :press-reportage
                                            (corpus-groups *brown*))))))
     #<TABLE-NGRAMS order:1 count:14395 outcomes:108130 {101C2B57E3}>
@@ -535,7 +535,7 @@ Well, we can double-check them from a different direction:
     NLP> (length (remove-if-not
                   #`(string= "can" %)
                   (mapcar #'token-word
-                          (flatten (mapcar #'text-tokens
+                          (flatten (mapcar #'text-tokenized
                                            (get# :press-reportage
                                                  (corpus-groups *brown*)))))))
     93

--- a/nltk/ch2-2.md
+++ b/nltk/ch2-2.md
@@ -40,7 +40,7 @@ Let's create the simplest distribution:
     NLTK> (make-cfd (maptable (lambda (topic texts)
                                 (declare (ignore topic))
                                 (mapcar #'token-word
-                                        (flatten (mapcar #'text-tokens texts))))
+                                        (flatten (mapcar #'text-tokenized texts))))
                               (corpus-groups +brown-corpus+)))
     #<HASH-TABLE :TEST EQL :COUNT 15 {101AA320A3}>
     NLTK> (defvar *cfd* *)
@@ -136,7 +136,7 @@ the case-insensitive version of the CFD:
 
     NLTK> (let ((cfd (make-cfd (maptable (lambda (topic texts)
                                            (mapcar #`(string-downcase (token-word %))
-                                                   (flatten (mapcar #'text-tokens
+                                                   (flatten (mapcar #'text-tokenized
                                                                     texts))))
                                          (corpus-groups +brown-corpus+)))))
             (dolist (m '("can" "could" "may" "might" "must" "will"))
@@ -200,7 +200,7 @@ because the corpus is keyed by text names, and we want a CFD keyed by words:
     (make-cfd (let ((ht (make-hash-table :test 'equalp)))
                 (dolist (text (corpus-texts *inaugural*))
                   (let ((year (sub (text-name text) 0 4)))
-                    (dolist (word (mapcar #'token-word (text-tokens text)))
+                    (dolist (word (mapcar #'token-word (text-tokenized text)))
                       (when-it (find word '("america" "citizen")
                                      :test #`(search %% % :test 'string-equal))
                         (set# it ht (cons year (get# it ht)))))))


### PR DESCRIPTION
This was changed some time ago. Fixes #26.